### PR TITLE
feat: Updated Logo in Orange and Techie Theme #22

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -100,21 +100,7 @@
       </g>
     </g>
 
-    <!-- forehead: small integrated-terminal motif -->
-    <g transform="translate(0,-200)">
-      <g filter="url(#glow)">
-        <rect x="-120" y="-34" width="240" height="68" rx="14" ry="14" fill="#2b2b2b" opacity="0.95"/>
-      </g>
-      <g transform="translate(-90,-18)">
-        <!-- tiny colored dots like window controls -->
-        <circle cx="0" cy="0" r="8" fill="#ff5f56"/>
-        <circle cx="28" cy="0" r="8" fill="#ffbd2e"/>
-        <circle cx="56" cy="0" r="8" fill="#27c93f"/>
-        <!-- terminal content: simple prompt and cursor -->
-        <text x="-10" y="30" font-family="monospace" font-size="26" fill="#d6d6d6">curavibe$</text>
-        <rect x="260" y="-10" width="10" height="20" rx="2" ry="2" fill="#ff6a00"/>
-      </g>
-    </g>
+  
 
     <!-- antenna shaped as curly brace to hint code (placed on top center) -->
     <g transform="translate(0,-417)">


### PR DESCRIPTION

![svgviewer-output](https://github.com/user-attachments/assets/b62baf81-a259-4a19-9c45-69ee3b051034)
This PR introduces a new logo for CuraVibe that aligns with the project’s tech-oriented style and orange theme.  

- The new logo is inspired by the previous logo but updated to better fit the brand identity.
- Designed with an orange color palette to match CuraVibe’s theme.
- SVG can be further optimized: suggested improvements include increasing the size of the eyes and other components for better visibility at smaller sizes.
- Contributors are welcome to tweak the SVG as needed for design refinements.

Fixes #22
